### PR TITLE
fix device view and strict typescript

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { HashRouter, Route, Switch } from 'react-router-dom';
 import styles from './App.module.css';
+import { ErrorBoundary } from './components/ErrorBoundery';
 import { Sidebar } from './components/Sidebar';
 import { DeviceProvider } from './contexts/DeviceProvider';
 import { SettingsProvider, useSettings } from './contexts/SettingsProvider';
@@ -26,15 +27,17 @@ const queryClient = new QueryClient({
 
 export function AppWrapper(): JSX.Element {
   return (
-    <HashRouter>
-      <QueryClientProvider client={queryClient}>
-        <SettingsProvider>
-          <DeviceProvider>
-            <App />
-          </DeviceProvider>
-        </SettingsProvider>
-      </QueryClientProvider>
-    </HashRouter>
+    <ErrorBoundary>
+      <HashRouter>
+        <QueryClientProvider client={queryClient}>
+          <SettingsProvider>
+            <DeviceProvider>
+              <App />
+            </DeviceProvider>
+          </SettingsProvider>
+        </QueryClientProvider>
+      </HashRouter>
+    </ErrorBoundary>
   );
 }
 
@@ -64,23 +67,27 @@ export function App(): JSX.Element {
   return (
     <div className={styles.root}>
       <Sidebar />
-      <Switch>
-        <Route exact path="/">
-          <Home />
-        </Route>
-        <Route exact path="/device">
-          <Device />
-        </Route>
-        <Route exact path="/category/:categoryId">
-          <Category />
-        </Route>
-        <Route exact path="/app/:slug">
-          <AppInfo />
-        </Route>
-        <Route exact path="/settings">
-          <AppSettings />
-        </Route>
-      </Switch>
+      <ErrorBoundary>
+        <Switch>
+          <Route exact path="/">
+            <Home />
+          </Route>
+          <Route exact path="/device">
+            <ErrorBoundary>
+              <Device />
+            </ErrorBoundary>
+          </Route>
+          <Route exact path="/category/:categoryId">
+            <Category />
+          </Route>
+          <Route exact path="/app/:slug">
+            <AppInfo />
+          </Route>
+          <Route exact path="/settings">
+            <AppSettings />
+          </Route>
+        </Switch>
+      </ErrorBoundary>
     </div>
   );
 }

--- a/src/components/AppRow.tsx
+++ b/src/components/AppRow.tsx
@@ -31,6 +31,11 @@ export function AppRow({ ...props }: Props): JSX.Element {
   async function install() {
     if (working) return;
 
+    if (!props.downloadUrl) {
+      console.error('App has no download url set!');
+      return;
+    }
+
     setWorking(true);
     await installApp(props.downloadUrl);
     setWorking(false);
@@ -79,7 +84,7 @@ export function AppRow({ ...props }: Props): JSX.Element {
       <div className={styles.actions}>
         {props.showLaunchBtn && <IconButton icon="play" title="Launch" onClick={() => launch()} />}
         {props.showCloseBtn && <IconButton icon="cancel" title="Close" onClick={() => close()} />}
-        {props.showInstallBtn && (
+        {props.showInstallBtn && props.downloadUrl && (
           <IconButton icon="install" title="Install" onClick={() => install()} />
         )}
         {props.showUninstallBtn && (

--- a/src/components/ErrorBoundery.tsx
+++ b/src/components/ErrorBoundery.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+// for reference see https://reactjs.org/docs/error-boundaries.html
+
+export class ErrorBoundary extends React.Component {
+  state: { hasError: boolean; error: null | string };
+  constructor(props: any) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: any) {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: any, errorInfo: any) {
+    console.error(error, errorInfo);
+    this.setState({ error: JSON.stringify({ error, errorInfo }, null, 4) });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return (
+        <div>
+          <h1>Something went wrong.</h1>
+          <code>
+            <pre>{this.state.error}</pre>
+          </code>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,23 @@
+declare global {
+  interface Window {
+    // see preload.ts for implementation
+    electron: {
+      kaiDevice: {
+        getInfo: () => Promise<DeviceInfo>;
+        getRunningApps: () => Promise<DeviceApp[]>;
+        getInstalledApps: () => Promise<DeviceApp[]>;
+        installApp: (url: string) => Promise<DeviceApp>;
+        installLocalApp: (url: string) => Promise<DeviceApp>;
+        uninstallApp: (appId: string) => Promise<void>;
+        launchApp: (appId: string) => Promise<void>;
+        closeApp: (appId: string) => Promise<void>;
+      };
+      browser: {
+        openUrl: (url: string) => Promise<void>;
+        downloadUrl: (url: string) => Promise<void>;
+      };
+    };
+  }
+}
+
+export {};

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,3 +1,5 @@
+import { DeviceInfo, DeviceApp } from './models';
+
 declare global {
   interface Window {
     // see preload.ts for implementation

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,9 +88,13 @@ ipcMain.handle('open-url', async (_, url: string) => {
   await shell.openExternal(url);
 });
 
-ipcMain.handle('download-url', async (_, url: string) => {
+ipcMain.handle('download-url', async ({ sender }, url: string) => {
   console.log('download-url', url);
-  const win = BrowserWindow.getFocusedWindow();
+  const win = BrowserWindow.fromWebContents(sender);
+  if (!win) {
+    throw new Error('BrowserWindow not found');
+  }
+  // would be better if
   await download(win, url, { saveAs: true });
 });
 

--- a/src/models/DeviceApp.ts
+++ b/src/models/DeviceApp.ts
@@ -1,11 +1,11 @@
 export interface DeviceApp {
   origin: string;
   installOrigin: string;
-  manifest: {
+  manifest?: {
     name: string;
     description: string;
     subtitle: string;
-    developer: {
+    developer?: {
       name: string;
       url: string;
     };

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
+// when updating this make also sure to update the type definitions in globals.d.ts as well
 contextBridge.exposeInMainWorld('electron', {
   kaiDevice: {
     getInfo: () => ipcRenderer.invoke('device-info'),

--- a/src/routes/AppInfo.tsx
+++ b/src/routes/AppInfo.tsx
@@ -15,7 +15,7 @@ type Params = {
 };
 
 export function AppInfo(): JSX.Element {
-  const [app, setApp] = useState<StoreApp>();
+  const [app, setApp] = useState<StoreApp | null>(null);
   const [working, setWorking] = useState(false);
   console.log('app', app);
 
@@ -33,19 +33,26 @@ export function AppInfo(): JSX.Element {
     setWorking(false);
   }
 
+  if (!app) {
+    return <View>Loading</View>;
+    // TODO
+    // Either make it not load by opening the component with the data it needs (so opener gets data and provides it to AppInfo via props)
+    // Or make a skeleton-placeholder / loading screen that gets displayed while `app === null`
+  }
+
   return (
     <View>
       <ViewHeader className={styles.header}>
-        <img src={app?.icon} alt="" />
+        <img src={app.icon} alt="" />
         <div>
           <Typography type="titleLarge" padding="none">
-            {app?.name || ''}
+            {app.name || ''}
           </Typography>
-          {app?.author ? (
-            <Typography padding="none">Author: {app?.author.join(', ')}</Typography>
+          {app.author ? (
+            <Typography padding="none">Author: {app.author.join(', ')}</Typography>
           ) : null}
-          {app?.maintainer ? (
-            <Typography padding="none">Maintainer: {app?.maintainer.join(', ')}</Typography>
+          {app.maintainer ? (
+            <Typography padding="none">Maintainer: {app.maintainer.join(', ')}</Typography>
           ) : null}
         </div>
         <div className={styles.actions}>
@@ -55,18 +62,18 @@ export function AppInfo(): JSX.Element {
             disabled={working}
             onClick={install}
           />
-          <Button text="Download" fullWidth={true} onClick={() => downloadUrl(app?.download.url)} />
+          <Button text="Download" fullWidth={true} onClick={() => downloadUrl(app.download.url)} />
         </div>
       </ViewHeader>
       <ViewContent className={styles.content}>
         <div className={styles.screenshots}>
-          {app?.screenshots.map((a, i) => (
+          {app.screenshots.map((a, i) => (
             <img key={i} src={a} alt="" />
           ))}
         </div>
         <section className={styles.section}>
           <Typography type="subtitle">Description</Typography>
-          <Typography padding="horizontal">{app?.description}</Typography>
+          <Typography padding="horizontal">{app.description}</Typography>
         </section>
         <section className={styles.section}>
           <Typography type="subtitle">Links</Typography>
@@ -74,13 +81,13 @@ export function AppInfo(): JSX.Element {
             <Typography display="inline" type="bodyStrong">
               Website:
             </Typography>
-            <BrowserLink url={app?.website} text={app?.website} />
+            <BrowserLink url={app.website} text={app.website} />
           </div>
           <div className={styles.infoRow}>
             <Typography display="inline" type="bodyStrong">
               Donate:
             </Typography>
-            <BrowserLink url={app?.donation} text={app?.donation} />
+            <BrowserLink url={app.donation} text={app.donation} />
           </div>
         </section>
         <section className={styles.section}>
@@ -89,19 +96,19 @@ export function AppInfo(): JSX.Element {
             <Typography display="inline" type="bodyStrong">
               Categories:
             </Typography>
-            <Typography display="inline">{app?.meta.categories.join(', ')}</Typography>
+            <Typography display="inline">{app.meta.categories.join(', ')}</Typography>
           </div>
           <div className={styles.infoRow}>
             <Typography display="inline" type="bodyStrong">
               Tags:
             </Typography>
-            <Typography display="inline">{app?.meta.tags.split('; ').join(', ')}</Typography>
+            <Typography display="inline">{app.meta.tags.split('; ').join(', ')}</Typography>
           </div>
           <div className={styles.infoRow}>
             <Typography display="inline" type="bodyStrong">
               License:
             </Typography>
-            <Typography display="inline">{app?.license}</Typography>
+            <Typography display="inline">{app.license}</Typography>
           </div>
         </section>
       </ViewContent>

--- a/src/routes/AppSettings.tsx
+++ b/src/routes/AppSettings.tsx
@@ -31,7 +31,7 @@ export function AppSettings(): JSX.Element {
               { value: Theme.Darker, label: 'Darker' },
               { value: Theme.Darkest, label: 'Darkest' },
             ]}
-            onChange={(val: Theme) => setSetting('theme', val)}
+            onChange={(val) => setSetting('theme', val)}
           />
         </div>
         <div className={styles.row}>
@@ -47,7 +47,7 @@ export function AppSettings(): JSX.Element {
               { value: TextSize.Large, label: 'Large' },
               { value: TextSize.Largest, label: 'Largest' },
             ]}
-            onChange={(val: TextSize) => setSetting('textSize', val)}
+            onChange={(val) => setSetting('textSize', val)}
           />
         </div>
       </ViewContent>

--- a/src/routes/Category.tsx
+++ b/src/routes/Category.tsx
@@ -28,7 +28,14 @@ export function Category(): JSX.Element {
   }, [categoryId]);
 
   async function getApps(forceRefresh = false) {
-    setData(await getAppsByCategory(categoryId, { forceRefresh }));
+    const apps = await getAppsByCategory(categoryId, { forceRefresh });
+    if (apps === null) {
+      console.error(`app filter by category failed, does the category exist: ${categoryId}?`);
+      setData(undefined);
+      // This shouldn't happen, but should we show a user visible error for this if it does?
+    } else {
+      setData(apps);
+    }
   }
 
   return (

--- a/src/routes/Device.tsx
+++ b/src/routes/Device.tsx
@@ -53,9 +53,9 @@ export function Device(): JSX.Element {
           <AppRow
             key={app.id}
             appId={app.id}
-            name={app.manifest.name}
-            author={app.manifest.developer.name}
-            description={app.manifest.description}
+            name={app.manifest?.name || '?'}
+            author={app.manifest?.developer?.name || '?'}
+            description={app.manifest?.description || '?'}
             installed={true}
             showCloseBtn={true}
             showUninstallBtn={true}
@@ -73,9 +73,9 @@ export function Device(): JSX.Element {
           <AppRow
             key={app.id}
             appId={app.id}
-            name={app.manifest.name}
-            author={app.manifest.developer.name}
-            description={app.manifest.description}
+            name={app.manifest?.name || '?'}
+            author={app.manifest?.developer?.name || '?'}
+            description={app.manifest?.description || '?'}
             installed={true}
             showLaunchBtn={true}
             showUninstallBtn={true}

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -8,10 +8,12 @@ import styles from './Home.module.css';
 export function Home(): JSX.Element {
   const [file, setFile] = useState<File>();
   const [working, setWorking] = useState(false);
-  const ref = useRef<HTMLInputElement>();
+  const ref = useRef<HTMLInputElement | null>(null);
 
   function reset() {
-    ref.current.value = null;
+    if (ref.current) {
+      ref.current.value = '';
+    }
     setFile(undefined);
   }
 
@@ -42,10 +44,11 @@ export function Home(): JSX.Element {
           type="file"
           accept="application/zip"
           onChange={(ev) => {
-            if (ev.target.files[0].name.endsWith('.zip')) {
-              setFile(ev.target.files[0]);
+            const file = ev.target.files && ev.target.files[0];
+            if (file?.name.endsWith('.zip')) {
+              setFile(file);
             } else {
-              ev.target.value = null;
+              ev.target.value = '';
             }
           }}
         />

--- a/src/services/browser.ts
+++ b/src/services/browser.ts
@@ -1,6 +1,6 @@
 export function openUrl(url: string): Promise<void> {
-  return (window as any).electron.browser.openUrl(url);
+  return window.electron.browser.openUrl(url);
 }
 export function downloadUrl(url: string): Promise<void> {
-  return (window as any).electron.browser.downloadUrl(url);
+  return window.electron.browser.downloadUrl(url);
 }

--- a/src/services/device.ts
+++ b/src/services/device.ts
@@ -1,33 +1,33 @@
 import { DeviceApp, DeviceInfo } from '../models';
 
 export function getDeviceInfo(): Promise<DeviceInfo> {
-  return (window as any).electron.kaiDevice.getInfo();
+  return window.electron.kaiDevice.getInfo();
 }
 
 export function getRunningApps(): Promise<DeviceApp[]> {
-  return (window as any).electron.kaiDevice.getRunningApps();
+  return window.electron.kaiDevice.getRunningApps();
 }
 
 export function getInstalledApps(): Promise<DeviceApp[]> {
-  return (window as any).electron.kaiDevice.getInstalledApps();
+  return window.electron.kaiDevice.getInstalledApps();
 }
 
 export function installApp(url: string): Promise<DeviceApp> {
-  return (window as any).electron.kaiDevice.installApp(url);
+  return window.electron.kaiDevice.installApp(url);
 }
 
 export function installLocalApp(filePath: string): Promise<DeviceApp> {
-  return (window as any).electron.kaiDevice.installLocalApp(filePath);
+  return window.electron.kaiDevice.installLocalApp(filePath);
 }
 
 export function uninstallApp(appId: string): Promise<void> {
-  return (window as any).electron.kaiDevice.uninstallApp(appId);
+  return window.electron.kaiDevice.uninstallApp(appId);
 }
 
 export function launchApp(appId: string): Promise<void> {
-  return (window as any).electron.kaiDevice.launchApp(appId);
+  return window.electron.kaiDevice.launchApp(appId);
 }
 
 export function closeApp(appId: string): Promise<void> {
-  return (window as any).electron.kaiDevice.closeApp(appId);
+  return window.electron.kaiDevice.closeApp(appId);
 }

--- a/src/services/store.ts
+++ b/src/services/store.ts
@@ -38,6 +38,10 @@ export async function getCategories(options?: Options): Promise<StoreCategory[]>
   return store.categories;
 }
 
+/**
+ *
+ * @returns apps for the specified category, null if not found
+ */
 export async function getAppsByCategory(
   categoryId: string,
   options?: Options
@@ -45,17 +49,24 @@ export async function getAppsByCategory(
   category: StoreCategory;
   apps: StoreApp[];
   fetchedAt: number;
-}> {
+} | null> {
   const store = await getStoreDb(options);
-  const category: StoreCategory = store.categories.find((a) => a.id === categoryId);
+  const category = store.categories.find((a) => a.id === categoryId);
+  if (!category) {
+    return null;
+  }
   const apps: StoreApp[] = store.apps.filter((a) =>
     a.meta.categories.includes(categoryId)
   ) as StoreApp[];
   return Promise.resolve({ category, apps, fetchedAt: store.fetchedAt });
 }
 
-export async function getAppBySlug(slug: string, options?: Options): Promise<StoreApp> {
+/**
+ *
+ * @returns the store app or null if not found
+ */
+export async function getAppBySlug(slug: string, options?: Options): Promise<StoreApp | null> {
   const store = await getStoreDb(options);
-  const app: StoreApp = store.apps.find((a) => a.slug === slug);
-  return app;
+  const app = store.apps.find((a) => a.slug === slug);
+  return app || null;
 }

--- a/src/ui-components/Select.tsx
+++ b/src/ui-components/Select.tsx
@@ -2,23 +2,23 @@ import React from 'react';
 import { ComponentBaseProps } from '../models';
 import styles from './Select.module.css';
 
-type Option = {
-  value: string;
+type Option<T extends string> = {
+  value: T;
   label: string;
 };
 
-type Props = ComponentBaseProps & {
-  value: string;
-  options: Option[];
-  onChange: (val: string) => void;
+type Props<T extends string> = ComponentBaseProps & {
+  value: T;
+  options: Option<T>[];
+  onChange: (val: T) => void | any;
 };
 
-export function Select(props: Props): JSX.Element {
+export function Select<T extends string>(props: Props<T>): JSX.Element {
   return (
     <select
       className={styles.root}
       value={props.value}
-      onChange={(ev) => props.onChange?.(ev.target.value)}
+      onChange={(ev) => props.onChange?.(ev.target.value as T)}
     >
       {props.options.map((opt) => (
         <option key={opt.value} value={opt.value}>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "allowJs": true,
     "module": "commonjs",
     "skipLibCheck": true,


### PR DESCRIPTION
- make device view work for me I had to make some manifest properties optional, because I have an app on my phone which does not have them. Not sure how much we can rely on manifest completeness in general...
- use strict typescript - add error Boundary's (so we don't get a completely white screen on errors, which was what happened for me before I fixed the device view) - don't show install button if there is no downloadUrl - make Select "Generic"


## When merging

please merge #5 before this pr and when merging this pr make sure to select **rebase** as merge method.
